### PR TITLE
Adding the ability to require authentication on the SMTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ If you want to use MailDev with [Docker](https://www.docker.com/), you can use t
       --outgoing-user <user>  SMTP user for outgoing emails
       --outgoing-pass <pass>  SMTP password for outgoing emails
       --outgoing-secure       Use SMTP SSL for outgoing emails
+      --incoming-user <user>  SMTP user for incoming emails
+      --incoming-pass <pass>  SMTP password for incoming emails
       -o, --open              Open the Web GUI after startup
       -v, --verbose
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports = function(config) {
       .option('--outgoing-user <user>', 'SMTP user for outgoing emails')
       .option('--outgoing-pass <pass>', 'SMTP password for outgoing emails')
       .option('--outgoing-secure', 'Use SMTP SSL for outgoing emails')
+      .option('--incoming-user <user>', 'SMTP user for incoming emails')
+      .option('--incoming-pass <pass>', 'SMTP password for incoming emails')
       .option('-o, --open', 'Open the Web GUI after startup')
       .option('-v, --verbose')
       .parse(process.argv);
@@ -38,7 +40,14 @@ module.exports = function(config) {
   }
   
   // Start the Mailserver & Web GUI
-  mailserver.listen( config.smtp );
+  if (
+      config.incomingUser &&
+      config.incomingPass
+      ){
+    mailserver.listen( config.smtp, config.incomingUser, config.incomingPass );
+  } else {
+    mailserver.listen( config.smtp );
+  }
   if (
       config.outgoingHost ||
       config.outgoingPort ||

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -166,12 +166,24 @@ function createTempFolder() {
  * Start the mailServer
  */
 
-mailServer.listen = function(port){
-
+mailServer.listen = function(port, user, password){
   // Start the server & Disable DNS checking
   smtp = simplesmtp.createServer({
-    disableDNSValidation: true
+    disableDNSValidation: true,
+    requireAuthentication: (user&&password),
+    incomingUser: user,
+    incomingPassword: password
   });
+
+  if (user&&password) {
+    smtp.on("authorizeUser", function(conn, username, password, callback){
+      if (username == this.options.incomingUser && password == this.options.incomingPassword) {
+        callback(null, true);
+      } else {
+        callback(new Error("Auth fail!"), false);
+      }
+    });
+  }
 
   // Setup temp folder for attachments
   createTempFolder();


### PR DESCRIPTION
Due to the requirement of having a public-facing SMTP server for testing purposes, I decided to implement authentication in MailDev, by adding a couple of command line options, and adding the required instantiation options to the simplesmtp instance, as well as the required authorizeUser event.