### PR TITLE
Adding HTTP auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ If you want to use MailDev with [Docker](https://www.docker.com/), you can use t
       --outgoing-user <user>  SMTP user for outgoing emails
       --outgoing-pass <pass>  SMTP password for outgoing emails
       --outgoing-secure       Use SMTP SSL for outgoing emails
+      --web-user <user>       HTTP basic auth username
+      --web-pass <pass>       HTTP basic auth password
       -o, --open              Open the Web GUI after startup
       -v, --verbose
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports = function(config) {
       .option('--outgoing-user <user>', 'SMTP user for outgoing emails')
       .option('--outgoing-pass <pass>', 'SMTP password for outgoing emails')
       .option('--outgoing-secure', 'Use SMTP SSL for outgoing emails')
+      .option('--web-user <user>', 'HTTP user for GUI')
+      .option('--web-pass <password>', 'HTTP password for GUI')
       .option('-o, --open', 'Open the Web GUI after startup')
       .option('-v, --verbose')
       .parse(process.argv);
@@ -54,7 +56,7 @@ module.exports = function(config) {
       , config.outgoingSecure
     );
   }
-  web.listen( config.web );
+  web.listen( config.web, config.webUser, config.webPass );
 
   logger.info('MailDev app running at 127.0.0.1:%s', config.web);
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,15 @@ module.exports = function(config) {
       , config.outgoingSecure
     );
   }
-  web.listen( config.web, config.webUser, config.webPass );
+  
+  if (
+      config.webUser &&
+      config.webPass
+      ){
+      web.enableAuthentication(config.webUser, config.webPass);
+  }
+  web.addRoutes();
+  web.listen( config.web );
 
   logger.info('MailDev app running at 127.0.0.1:%s', config.web);
 

--- a/lib/web.js
+++ b/lib/web.js
@@ -18,7 +18,7 @@ var express     = require('express')
 
 module.exports = {
   listen: function(port, user, password) {
-    // Add authentication is user and password provided
+    // Add authentication if user and password provided
     if (user&&password) {
       app.use(function(req, res, next) {
         var auth;

--- a/lib/web.js
+++ b/lib/web.js
@@ -17,156 +17,167 @@ var express     = require('express')
  */
 
 module.exports = {
-  listen: function(port, user, password) {
-    // Add authentication if user and password provided
-    if (user&&password) {
-      app.use(function(req, res, next) {
-        var auth;
-        if (req.headers.authorization) {
-          auth = new Buffer(req.headers.authorization.substring(6), 'base64').toString().split(':');
-        }
-
-        if (!auth || auth[0] !== user || auth[1] !== password) {
-          res.statusCode = 401;
-          res.setHeader('WWW-Authenticate', 'Basic realm="Authentication required"');
-          res.send('Unauthorized');
-        } else {
-          next();
-        }
-      });
-    }
-
-    // Add our static files route
-    app.use('/', express.static(__dirname + '../../app'));
-
-    // Pass through to the server listen method
-    server.listen(port);
-  }
+  listen: listen,
+  addRoutes: addRoutes,
+  enableAuthentication: enableAuthentication
 };
+
+/**
+ * Intermediary for server.listen method
+ */
+
+function listen(port) {
+  server.listen(port);
+}
 
 /**
  * Requests
  */
+ 
+function addRoutes() {
+  app.use('/', express.static(__dirname + '../../app'));
+  
+  // Get all emails
+  app.get('/email', function(req, res){
 
-// Get all emails
-app.get('/email', function(req, res){
+    mailserver.getAllEmail(function(err, emailList){
+      if (err) return res.status(404).json([]);
 
-  mailserver.getAllEmail(function(err, emailList){
-    if (err) return res.status(404).json([]);
+      res.json(emailList);
+    });
 
-    res.json(emailList);
   });
 
-});
+  // Get single email
+  app.get('/email/:id', function(req, res){
 
-// Get single email
-app.get('/email/:id', function(req, res){
+    mailserver.getEmail( req.params.id, function(err, email){
+      if (err) return res.status(404).json({ error: err.message });
 
-  mailserver.getEmail( req.params.id, function(err, email){
-    if (err) return res.status(404).json({ error: err.message });
+       // Mark the email as 'read'
+      email.read = true;
 
-     // Mark the email as 'read'
-    email.read = true;
+      res.json(email);
+    });
 
-    res.json(email);
   });
 
-});
+  // Delete all emails
+  app.delete('/email/all', function(req, res){
 
-// Delete all emails
-app.delete('/email/all', function(req, res){
-
-  mailserver.deleteAllEmail(function(err){
-    if (err) return res.status(500).json({ error: err.message });
-
-    res.json(true);
-  });
-
-});
-
-// Delete email by id
-app.delete('/email/:id', function(req, res){
-
-  mailserver.deleteEmail(req.params.id, function(err){
-    if (err) return res.status(500).json({ error: err.message });
-
-    res.json(true);
-  });
-
-});
-
-// Get Email HTML
-app.get('/email/:id/html', function(req, res){
-
-  mailserver.getEmail( req.params.id, function(err, email){
-    if (err) return res.status(404).json({ error: err.message });
-
-    res.send(email.html);
-  });
-
-});
-
-// Serve Attachments
-app.get('/email/:id/attachment/:filename', function(req, res){
-
-  mailserver.getEmailAttachment(req.params.id, req.params.filename, function(err, contentType, readStream){
-    if (err) return res.status(404).json('File not found');
-
-    res.contentType(contentType);
-    readStream.pipe(res);
-  });
-
-});
-
-// Serve email.eml
-app.get('/email/:id/download', function(req, res){
-
-  mailserver.getEmailEml(req.params.id, function(err, contentType, filename, readStream){
-    if (err) return res.status(404).json('File not found');
-
-    res.setHeader('Content-disposition', 'attachment; filename=' + filename);
-    res.contentType(contentType);
-    readStream.pipe(res);
-  });
-
-});
-
-// Get email source from .eml file
-app.get('/email/:id/source', function(req, res){
-
-  mailserver.getRawEmail( req.params.id, function(err, readStream){
-
-    if (err) return res.status(404).json('File not found');
-    readStream.pipe(res);
-  });
-
-});
-
-// Get any config settings for display
-app.get('/config', function(req, res){
-
-  res.json({
-    version:  pkg.version
-  , smtpPort: mailserver.port
-  , outgoingHost: mailserver.outgoingHost
-  });
-
-});
-
-
-// Relay the email
-app.post('/email/:id/relay', function(req, res){
-  mailserver.getEmail(req.params.id, function(err, email){
-    if (err) return res.status(404).json({ error: err.message });
-
-    mailserver.relayMail(email, function(err) {
+    mailserver.deleteAllEmail(function(err){
       if (err) return res.status(500).json({ error: err.message });
 
       res.json(true);
     });
 
   });
-});
+
+  // Delete email by id
+  app.delete('/email/:id', function(req, res){
+
+    mailserver.deleteEmail(req.params.id, function(err){
+      if (err) return res.status(500).json({ error: err.message });
+
+      res.json(true);
+    });
+
+  });
+
+  // Get Email HTML
+  app.get('/email/:id/html', function(req, res){
+
+    mailserver.getEmail( req.params.id, function(err, email){
+      if (err) return res.status(404).json({ error: err.message });
+
+      res.send(email.html);
+    });
+
+  });
+
+  // Serve Attachments
+  app.get('/email/:id/attachment/:filename', function(req, res){
+
+    mailserver.getEmailAttachment(req.params.id, req.params.filename, function(err, contentType, readStream){
+      if (err) return res.status(404).json('File not found');
+
+      res.contentType(contentType);
+      readStream.pipe(res);
+    });
+
+  });
+
+  // Serve email.eml
+  app.get('/email/:id/download', function(req, res){
+
+    mailserver.getEmailEml(req.params.id, function(err, contentType, filename, readStream){
+      if (err) return res.status(404).json('File not found');
+
+      res.setHeader('Content-disposition', 'attachment; filename=' + filename);
+      res.contentType(contentType);
+      readStream.pipe(res);
+    });
+
+  });
+
+  // Get email source from .eml file
+  app.get('/email/:id/source', function(req, res){
+
+    mailserver.getRawEmail( req.params.id, function(err, readStream){
+
+      if (err) return res.status(404).json('File not found');
+      readStream.pipe(res);
+    });
+
+  });
+
+  // Get any config settings for display
+  app.get('/config', function(req, res){
+
+    res.json({
+      version:  pkg.version
+    , smtpPort: mailserver.port
+    , outgoingHost: mailserver.outgoingHost
+    });
+
+  });
+
+
+  // Relay the email
+  app.post('/email/:id/relay', function(req, res){
+    mailserver.getEmail(req.params.id, function(err, email){
+      if (err) return res.status(404).json({ error: err.message });
+
+      mailserver.relayMail(email, function(err) {
+        if (err) return res.status(500).json({ error: err.message });
+
+        res.json(true);
+      });
+
+    });
+  });
+}
+
+/**
+ * Addition of Basic Auth middleware
+ */
+
+function enableAuthentication(user, password) {
+ app.use(function(req, res, next) {
+   var auth;
+   if (req.headers.authorization) {
+     auth = new Buffer(req.headers.authorization.substring(6), 'base64').toString().split(':');
+   }
+
+   if (!auth || auth[0] !== user || auth[1] !== password) {
+     res.statusCode = 401;
+     res.setHeader('WWW-Authenticate', 'Basic realm="Authentication required"');
+     res.send('Unauthorized');
+   } else {
+     next();
+   }
+ });
+}
 
 /**
  * Socket.io

--- a/lib/web.js
+++ b/lib/web.js
@@ -16,10 +16,33 @@ var express     = require('express')
  * Exports
  */
 
-module.exports = server;
+module.exports = {
+  listen: function(port, user, password) {
+    // Add authentication is user and password provided
+    if (user&&password) {
+      app.use(function(req, res, next) {
+        var auth;
+        if (req.headers.authorization) {
+          auth = new Buffer(req.headers.authorization.substring(6), 'base64').toString().split(':');
+        }
 
-app.use('/', express.static(__dirname + '../../app'));
+        if (!auth || auth[0] !== user || auth[1] !== password) {
+          res.statusCode = 401;
+          res.setHeader('WWW-Authenticate', 'Basic realm="Authentication required"');
+          res.send('Unauthorized');
+        } else {
+          next();
+        }
+      });
+    }
 
+    // Add our static files route
+    app.use('/', express.static(__dirname + '../../app'));
+
+    // Pass through to the server listen method
+    server.listen(port);
+  }
+};
 
 /**
  * Requests
@@ -144,7 +167,6 @@ app.post('/email/:id/relay', function(req, res){
 
   });
 });
-
 
 /**
  * Socket.io


### PR DESCRIPTION
Added HTTP auth option, following from a requirement internally, and Issue #47 

I'm not sure if the way I've done this is correct or not, but it appears to work for our setup. I've had to override the 'listen' export originally provided by 'server', as the static route was allowing bypass of the auth middleware.

If you can think of improvements to be made to this, I'm all ears. Relatively new to NodeJS (though not JS), so completely open to criticism.

Thanks