### PR TITLE
Prevent full refresh of UI when deleting a single email

### DIFF
--- a/app/scripts/controllers/item.js
+++ b/app/scripts/controllers/item.js
@@ -117,9 +117,8 @@ app.controller('ItemCtrl', [
     $scope.delete = function(item) {
 
       Email.delete({ id: item.id }, function(email) {
-        var emailElement = document.getElementsByClassName("email-"+item.id)[0];
-        if (emailElement.classList.contains("current")) $location.path("/");
-        emailElement.parentNode.removeChild(emailElement);
+        $location.path('/');
+        $scope.items.splice($scope.items.indexOf($scope.items.filter(function(item_){return item.id==item_.id})[0]),1);
       });
 
     };

--- a/app/scripts/controllers/item.js
+++ b/app/scripts/controllers/item.js
@@ -117,8 +117,9 @@ app.controller('ItemCtrl', [
     $scope.delete = function(item) {
 
       Email.delete({ id: item.id }, function(email) {
-        $rootScope.$emit('Refresh');
-        $location.path('/');
+        var emailElement = document.getElementsByClassName("email-"+item.id)[0];
+        if (emailElement.classList.contains("current")) $location.path("/");
+        emailElement.parentNode.removeChild(emailElement);
       });
 
     };


### PR DESCRIPTION
This pull request addresses issue #60. Instead of performing a full refresh and redrawing the whole UI, this will, upon a successful delete, first of all find the email element for the email being deleted, navigate to the root path if the email is currently selected, and then remove the email element from its parent.