### PR TITLE
Add ability to specify binding IP address for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierprio
       --outgoing-secure       Use SMTP SSL for outgoing emails
       --web-user <user>       HTTP basic auth username
       --web-pass <pass>       HTTP basic auth password
+      --bind <ip address>     IP Address to bind services to [0.0.0.0]
       -o, --open              Open the Web GUI after startup
       -v, --verbose
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = function(config) {
       .option('--outgoing-secure', 'Use SMTP SSL for outgoing emails')
       .option('--web-user <user>', 'HTTP user for GUI')
       .option('--web-pass <password>', 'HTTP password for GUI')
+      .option('--bind <ip address>', 'IP Address to bind services to', '0.0.0.0')
       .option('-o, --open', 'Open the Web GUI after startup')
       .option('-v, --verbose')
       .parse(process.argv);
@@ -40,7 +41,7 @@ module.exports = function(config) {
   }
   
   // Start the Mailserver & Web GUI
-  mailserver.listen( config.smtp );
+  mailserver.listen( config.smtp, config.bind );
 
   if (config.outgoingHost ||
       config.outgoingPort ||
@@ -57,13 +58,13 @@ module.exports = function(config) {
     );
   }
 
-  web.start(config.web, mailserver, config.webUser, config.webPass);
+  web.start(config.web, config.bind, mailserver, config.webUser, config.webPass);
 
-  logger.info('MailDev app running at 127.0.0.1:%s', config.web);
+  logger.info('MailDev app running at %s:%s', config.bind, config.web);
 
   if (config.open){
     var open = require('open');
-    open('http://localhost:' + config.web);
+    open('http://' + (config.bind == '0.0.0.0' ? 'localhost' : config.bind) + ':' + config.web);
   }
 
   return mailserver;

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -12,6 +12,7 @@ var os            = require('os');
 var path          = require('path');
 
 var defaultPort   = 1025;
+var defaultHost   = '0.0.0.0';
 var store         = [];
 var tempDir       = path.join(os.tmpdir(), 'maildev', process.pid.toString());
 var eventEmitter  = new events.EventEmitter();
@@ -163,7 +164,7 @@ function createTempFolder() {
  * Start the mailServer
  */
 
-mailServer.listen = function(port){
+mailServer.listen = function(port, host){
 
   // Start the server & Disable DNS checking
   smtp = simplesmtp.createServer({
@@ -174,11 +175,12 @@ mailServer.listen = function(port){
   createTempFolder();
 
   mailServer.port = port || defaultPort;
+  mailServer.host   = host || defaultHost;
 
   // Listen on the specified port
-  smtp.listen(port, function(err){
+  smtp.listen(port, host, function(err){
     if (err) throw err;
-    logger.info('MailDev SMTP Server running at 127.0.0.1:%s', mailServer.port);
+    logger.info('MailDev SMTP Server running at %s:%s', mailServer.host, mailServer.port);
   });
 
   // Bind events to stream

--- a/lib/web.js
+++ b/lib/web.js
@@ -39,7 +39,7 @@ function webSocketConnection(mailserver) {
  * Start the web server
  */
 
-module.exports.start = function(port, mailserver, user, password) {
+module.exports.start = function(port, host, mailserver, user, password) {
 
   if (user && password) {
     app.use(auth(user, password));  
@@ -51,6 +51,6 @@ module.exports.start = function(port, mailserver, user, password) {
 
   io.on('connection', webSocketConnection(mailserver));
 
-  server.listen(port);
+  server.listen(port, host);
 
 };


### PR DESCRIPTION
This pull request adds the ability to specify the binding IP address for the HTTP and SMTP services. To prevent breaking any existing versions, this defaults to '0.0.0.0', as the current version binds to all IP addresses (instead of 127.0.0.1, as the console log suggests).

Added in relation to issue #11 