### PR TITLE
[Breaking] Change API listen method. Add create method.

### DIFF
--- a/bin/maildev
+++ b/bin/maildev
@@ -6,4 +6,5 @@ var fs = require('fs');
 var root = path.join(path.dirname(fs.realpathSync(__filename)), '../');
 var MailDev = require(root + '/index.js');
 
-new MailDev();
+var maildev = new MailDev();
+maildev.listen();

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,10 @@ var maildev = new MailDev({
   smtp: 1025 // incoming SMTP port - default is 1025
 });
 
+maildev.listen(function(err) {
+  console.log('We can now sent emails to port 1025!');
+});
+
 // Print new emails to the console as they come in
 maildev.on('new', function(email){
   console.log('Received new email with subject: %s', email.subject);
@@ -37,6 +41,8 @@ var maildev = new MailDev({
   outgoingPass: '********'
 });
 
+maildev.listen();
+
 // Print new emails to the console as they come in
 maildev.on('new', function(email){
   
@@ -58,6 +64,10 @@ maildev.on('new', function(email){
 
 *All callbacks follow the Node error-first pattern, ex.* `function(err, data){...`
 
+**listen(callback)** - Starts the smtp server 
+
+**end(callback)** - Stops the smtp server
+
 **on('new', callback)** - Event called when a new email is received. Callback 
 receives single mail object.
 
@@ -77,5 +87,3 @@ readable stream of the file. Example callback:
 
 **relayMail(id, callback)** - If configured, this will relay/send the given
 email to it's "to" address. Also accepts an email object instead of id.
-
-**end()** - Stops the mail server

--- a/index.js
+++ b/index.js
@@ -45,9 +45,9 @@ module.exports = function(config) {
   // Start the Mailserver & Web GUI
   if (config.incomingUser &&
       config.incomingPass) {
-    mailserver.listen( config.smtp, config.bind, config.incomingUser, config.incomingPass );
+    mailserver.create( config.smtp, config.bind, config.incomingUser, config.incomingPass );
   } else {
-    mailserver.listen( config.smtp, config.bind );
+    mailserver.create( config.smtp, config.bind );
   }
 
   if (config.outgoingHost ||

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -161,10 +161,10 @@ function createTempFolder() {
 
 
 /**
- * Start the mailServer
+ * Create and configure the mailserver
  */
 
-mailServer.listen = function(port, host, user, password){
+mailServer.create = function(port, host, user, password, callback) {
 
   // Start the server & Disable DNS checking
   smtp = simplesmtp.createServer({
@@ -190,18 +190,38 @@ mailServer.listen = function(port, host, user, password){
 
   mailServer.port = port || defaultPort;
   mailServer.host = host || defaultHost;
+};
 
-  // Listen on the specified port
-  smtp.listen(port, host, function(err){
-    if (err) throw err;
-    logger.info('MailDev SMTP Server running at %s:%s', mailServer.host, mailServer.port);
-  });
+
+/**
+ * Start the mailServer
+ */
+
+mailServer.listen = function(callback) {
+
+  if (typeof callback !== 'function') callback = null;
 
   // Bind events to stream
   smtp.on('startData', newStream);
   smtp.on('data',      writeChunk);
   smtp.on('dataReady', endStream);
+
+  // Listen on the specified port
+  smtp.listen(mailServer.port, mailServer.host, function(err) {
+    if (err) {
+      if (callback) {
+        callback(err);
+      } else {
+        throw err;
+      }
+    }
+
+    if (callback) callback();
+
+    logger.info('MailDev SMTP Server running at %s:%s', mailServer.host, mailServer.port);
+  });
 };
+
 
 /**
  * Stop the mailserver


### PR DESCRIPTION
There was no way to run the maildev server programmatically and ensure the smtp server was running via callback. Breaking changes:

* Instantiating MailDev's exported function no longer starts the smtp server
* The old `listen` method has been replaced with two methods:
  * `create` - this accepts the options arguments as the old `listen` method used to
  * `listen` - this starts the smtp server and accepts a single callback which is called when the smtp server is up and running
