### PR TITLE
Add .listen() to the API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ var MailDev = require('maildev');
 
 var maildev = new MailDev();
 
+maildev.listen();
+
 maildev.on('new', function(email){
   // We got a new email!
 });


### PR DESCRIPTION
As I understand it, calling `listen()` wasn't needed before v0.10... this change to the README may help to avoid confusion.