### PR TITLE
Replace simplesmtp with smtp-server and smtp-connection djfarrelly/MailDev#30

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -218,7 +218,7 @@ mailServer.listen = function(callback) {
  */
 
 mailServer.end = function(done){
-  smtp.end(done);
+  smtp.close(done);
 };
 
 

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -3,7 +3,8 @@
  * MailDev - mailserver.js
  */
 
-var simplesmtp    = require('simplesmtp');
+var SMTPServer    = require('smtp-server').SMTPServer;
+var SMTPConnection = require('smtp-connection');
 var MailParser    = require('mailparser').MailParser;
 var events        = require('events');
 var logger        = require('./logger');
@@ -71,37 +72,29 @@ function saveAttachment(attachment){
   attachment.stream.pipe(output);
 }
 
-
-// SMTP server stream functions
-function newStream(connection){
-
+function newStream(stream, session, callback) {
   var id = makeId();
 
-  connection.saveStream = new MailParser({
+  session.saveStream = new MailParser({
     streamAttachments: true
   });
-  connection.saveRawStream = fs.createWriteStream(path.join(tempDir, id + '.eml'));
-
-  connection.saveStream.on('attachment', saveAttachment);
-  connection.saveStream.on('end', saveEmail.bind(null,id, {
-    from: connection.from,
-    to: connection.to,
-    host: connection.host,
-    remoteAddress: connection.remoteAddress
+  session.saveRawStream = fs.createWriteStream(path.join(tempDir, id + '.eml'));
+  
+  stream.pipe(session.saveStream);
+  stream.pipe(session.saveRawStream);
+  
+  stream.on('end', function(){
+    session.saveRawStream.end();
+    callback(null, 'Message queued as '+id);
+  });
+  
+  session.saveStream.on('end', saveEmail.bind(null,id, {
+    from: session.envelope.mailFrom,
+    to: session.envelope.rcptTo,
+    host: session.hostNameAppearsAs,
+    remoteAddress: session.remoteAddress
   }));
-}
-
-function writeChunk(connection, chunk){
-  connection.saveStream.write(chunk);
-  connection.saveRawStream.write(chunk);
-}
-
-function endStream(connection, done){
-  connection.saveStream.end();
-  connection.saveRawStream.end();
-  // ABC is the queue id to be advertised to the client
-  // There is no current significance to this.
-  done(null, 'ABC');
+  session.saveStream.on('attachment', saveAttachment);
 }
 
 
@@ -163,13 +156,13 @@ function createTempFolder() {
  * Authorize callback for smtp server
  */
 
-function authorizeUser(conn, username, password, callback) {
-  if (username === this.options.incomingUser && 
-      password === this.options.incomingPassword) {
-    callback(null, true);
-  } else {
-    callback(new Error('Auth fail!'), false);
+function authorizeUser(auth, session, callback) {
+  if (this.options.incomingUser && this.options.incomingPassword) {
+    if (auth.username !== this.options.incomingUser || auth.password !== this.options.incomingPassword) {
+      return callback(new Error('Invalid username or password'));
+    }
   }
+  callback(null, {user: this.options.incomingUser});
 }
 
 
@@ -180,16 +173,13 @@ function authorizeUser(conn, username, password, callback) {
 mailServer.create = function(port, host, user, password) {
 
   // Start the server & Disable DNS checking
-  smtp = simplesmtp.createServer({
-    disableDNSValidation: true,
-    requireAuthentication: !!(user && password),
+  smtp = new SMTPServer({
     incomingUser: user,
-    incomingPassword: password
+    incomingPassword: password,
+    onAuth: authorizeUser,
+    onData: newStream,
+    disabledCommands: !!(user && password)?['STARTTLS']:['AUTH']
   });
-
-  if (user && password) {
-    smtp.on('authorizeUser', authorizeUser);
-  }
 
   // Setup temp folder for attachments
   createTempFolder();
@@ -206,12 +196,6 @@ mailServer.create = function(port, host, user, password) {
 mailServer.listen = function(callback) {
 
   if (typeof callback !== 'function') callback = null;
-
-  // Bind events to stream
-  smtp.on('startData', newStream);
-  smtp.on('data',      writeChunk);
-  smtp.on('dataReady', endStream);
-
   // Listen on the specified port
   smtp.listen(mailServer.port, mailServer.host, function(err) {
     if (err) {
@@ -381,24 +365,15 @@ mailServer.setupOutgoing = function(host, port, user, pass, secure){
   secure = secure || false;
 
   try {
-
-    // Forward Mail options
-    var options = {
-      secureConnection: secure,
-      maxMessages: 1,
+    mailServer.client = new SMTPConnection({
+      port: port,
+      host: host,
+      secure: secure,
+      auth: (pass && user) ? { user: user, pass: pass } : false,
+      tls: {rejectUnauthorized: false},
       debug: true
-    };
-
-    if (pass && user) {
-      options.auth = {
-        user: user,
-        pass: pass
-      };
-    }
-
-
-    mailServer.clientPool = simplesmtp.createClientPool(port, host, options);
-
+    });
+    
     logger.info(
       'MailDev outgoing SMTP Server %s:%d (user:%s, pass:%s, secure:%s)',
       host,
@@ -419,7 +394,7 @@ mailServer.setupOutgoing = function(host, port, user, pass, secure){
  */
 
 mailServer.relayMail = function(idOrMailObject, done){
-  if (!mailServer.clientPool)
+  if (!mailServer.client)
     return done(new Error('Outgoing mail not configured'));
 
   // If we receive a email id, get the email object
@@ -438,26 +413,36 @@ mailServer.relayMail = function(idOrMailObject, done){
       console.error('Mail Stream Error: ', err);
       return done(err);
     }
-
-    //simplesmtp accepts a "MailComposer compatible" object
-    var mailComposer = rawEmailStream;
-    mailComposer.getEnvelope = function(){
-      return mail.envelope;
-    };
-    mailComposer.streamMessage = function(){
-      //noop
-    };
-
-    mailServer.clientPool.sendMail(mailComposer, function(err, response){
+    
+    var mailConnectCallback = function(err, info) {
       if (err) {
-        console.error('Mail Delivery Error: ', err);
+        console.error('Mail Connection Error: ', err);
         return done(err);
       }
-
-      logger.log('Mail Delivered: ', mail.subject);
-      done();
-    });
-
+      
+      var mailSendCallback = function(err, info) {
+        mailServer.client.send({
+          from: mail.envelope.from.address,
+          to: mail.envelope.to.map(function(toItem) { return toItem.address })
+        }, rawEmailStream, function (err, info) {
+          if (err) {
+            console.error('Mail Delivery Error: ', err);
+            return done(err);
+          }
+          
+          logger.log('Mail Delivered: ', mail.subject)
+          return done();
+        });
+      }
+      
+      if (mailServer.client.options.auth) {
+        mailServer.client.login(mailServer.client.options.auth, mailSendCallback)
+      } else {
+        mailSendCallback(err, info);
+      }
+    };
+    
+    mailServer.client.connect(mailConnectCallback);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "mailcomposer": "~0.2.11",
     "mailparser": "^0.5.0",
     "open": "~0.0.5",
-    "simplesmtp": "^0.3.35",
+    "smtp-connection": "^1.2.0",
+    "smtp-server": "^1.4.0",
     "socket.io": "^1.3.5"
   },
   "devDependencies": {
@@ -52,7 +53,7 @@
     "smtp-connection": "^1.2.0"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.4"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha"


### PR DESCRIPTION
RE djfarrelly/MailDev#30

I've tested receiving emails with and without attachments, as well as relaying with and without authentication. All appears to work, however I'm not sure about the definitions of the callbacks in lib/mailserver.js around lines 417-466 (in particular mailConnectCallback and mailSendCallback). Open to suggestions as to how it can be improved - it just feels messy scoping them like that.

The change to smtp-server and smtp-connection does require NodeJS 0.12, as it depends upon Sets, which became available with 0.12.