### PR TITLE
Add option to bind HTTP front to different address than SMTP server

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -26,7 +26,7 @@ app.run(['$rootScope', function($rootScope){
 
   socket.on('deleteMail', function(data) {
     $rootScope.$emit('deleteMail', data);
-  })
+  });
   
   $rootScope.$on('Refresh', function() {
     console.log('Refresh event called.');

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -59,7 +59,7 @@ app.controller('MainCtrl', [
     });
     
     $rootScope.$on('deleteMail', function(e, email) {
-      if (email.id == 'all') {
+      if (email.id === 'all') {
         $rootScope.$emit('Refresh');
         $location.path('/');
       } else {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(config) {
       .version(version)
       .option('-s, --smtp <port>', 'SMTP port to catch emails [1025]', '1025')
       .option('-w, --web <port>', 'Port to run the Web GUI [1080]', '1080')
-      .option('--ip <ip address>', 'IP Address to bind services to', '0.0.0.0')
+      .option('--ip <ip address>', 'IP Address to bind SMTP service to', '0.0.0.0')
       .option('--outgoing-host <host>', 'SMTP host for outgoing emails')
       .option('--outgoing-port <port>', 'SMTP port for outgoing emails')
       .option('--outgoing-user <user>', 'SMTP user for outgoing emails')
@@ -31,6 +31,7 @@ module.exports = function(config) {
       .option('--outgoing-secure', 'Use SMTP SSL for outgoing emails')
       .option('--incoming-user <user>', 'SMTP user for incoming emails')
       .option('--incoming-pass <pass>', 'SMTP password for incoming emails')
+      .option('--web-ip <ip address>', 'IP Address to bind HTTP service to, defaults to --ip')
       .option('--web-user <user>', 'HTTP user for GUI')
       .option('--web-pass <password>', 'HTTP password for GUI')
       .option('-o, --open', 'Open the Web GUI after startup')
@@ -60,7 +61,7 @@ module.exports = function(config) {
     );
   }
 
-  web.start(config.web, config.ip, mailserver, config.webUser, config.webPass);
+  web.start(config.web, config.webIp ? config.webIp : config.ip, mailserver, config.webUser, config.webPass);
 
   if (config.open){
     var open = require('open');

--- a/lib/web.js
+++ b/lib/web.js
@@ -24,7 +24,7 @@ function emitNewMail(socket) {
 
 function emitDeleteMail(socket) {
   return function(email) {
-    socket.emit('deleteMail', email)
+    socket.emit('deleteMail', email);
   };
 }
 


### PR DESCRIPTION
I'm using MailDev as my mail server for local tests, and now want to use it for my staging environment as well. Best way to be sure my pre-prod mails don't end up in actual client mailboxes...

Issue is, the staging server is out there in the cloud, so in order to access the HTTP front from my development machine, I need to bind the http server to 0.0.0.0 (and secure with user+password), but I do not want to expose the SMTP port to the internet (keep it bound to 127.0.0.1)

So I added a `--web-ip` option to specify which address to bind the web front to.
For backward compatibility with #63, if only `--ip` is specified it binds http to it as well.

PS: I also fixed 3 jshint complaints in unrelated files, to get a clean build.
