### PR TITLE
Save space on Docker image by using node:slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
-FROM node:5-onbuild
+FROM node:5-slim
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ADD package.json /usr/src/app/
+RUN npm install
+ADD . /usr/src/app
+
 EXPOSE 80 25
+
 CMD ["bin/maildev", "--web", "80", "--smtp", "25"]


### PR DESCRIPTION
Basically the same `Dockerfile` as [`node:5-onbuild`](https://github.com/nodejs/docker-node/blob/c4868ce25f75d47e3ec75e6479664d8c46fc990e/5.4/onbuild/Dockerfile) but based on `slim` image.

Built image size on master: 715.6 MB 
Built image size on my PR: 278.4 MB

With this, you're saving **437,2 MB** of space, it's quite huge.

I think Docker should create a `slim-onbuild` tag on the official repository.