### PR TITLE
Docker verbose option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
 FROM node:5-onbuild
+
+ENV VERBOSE 0
+
 EXPOSE 80 25
-CMD ["bin/maildev", "--web", "80", "--smtp", "25"]
+
+ADD entrypoint.sh /
+RUN chmod u+x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["sh", "-c", "bin/maildev --web 80 --smtp 25"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 If you want to use MailDev with [Docker](https://www.docker.com/), you can use the ['djfarrelly/maildev' image on Docker Hub](https://registry.hub.docker.com/u/djfarrelly/maildev/).
 
+Docker environment options:
+
+* `VERBOSE`: Set `--verbose` option. Default to `0`, `1` for activation.
+
 For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierpriour/grunt-maildev).
 
 ## Usage

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -e
+
+OPTS=""
+
+if [ "${VERBOSE}" = 1 ]; then
+    OPTS="${OPTS} --verbose"
+fi
+
+exec "$@ ${OPTS}"


### PR DESCRIPTION
Here is a PoC as suggested on https://github.com/djfarrelly/MailDev/issues/100#issuecomment-172815644.

I just added verbose options but we can add more.

But I agree that having a `maildev.json` configuration file (https://github.com/djfarrelly/MailDev/issues/93) would be easier. With that, we will just have to link our config file to the docker container.
