### PR TITLE
Fixing path to static directory

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -10,7 +10,7 @@ var io = require('socket.io').listen(server);
 var routes = require('./routes');
 var auth = require('./auth');
 var logger = require('./logger');
-
+var path = require('path');
 
 /**
  * WebSockets
@@ -54,7 +54,7 @@ module.exports.start = function(port, host, mailserver, user, password) {
     app.use(auth(user, password));
   }
 
-  app.use('/', express.static(__dirname + '../../app'));
+  app.use('/', express.static(path.join(__dirname, '../app')));
 
   routes(app, mailserver);
 


### PR DESCRIPTION
This PR addresses the issue seen in more modern node versions. The path for the static files appears to be traversing one level too many. I've removed the extra level of traversal and am making use of the `path` module to join the paths together.

I've tested this solution on versions v0.10.40, v0.12.7 and v5.7.1. In all three versions the GUI displays as expected. This was tested by updating to the target `node` versions and installing the `maildev` package on each using `npm`. The change was also tested by cloning the project down in each version, and then running `bin/maildev`.

This resolves issue #106 

p.s. Nice to see this is still going @djfarrelly - love the additions! :+1: 