### PR TITLE
Fix attachments when using nodemailer

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -59,6 +59,14 @@ function makeId(){
 
 // Save an email object on stream end
 function saveEmail(id, envelope, mailObject){
+  
+  // remove stream object from attachments (fix the JSON.stringify)
+  if (mailObject.attachments instanceof Array) {
+    mailObject.attachments.forEach((attachment) => {
+      delete attachment.stream;
+    });
+  }
+
   var object = clone(mailObject);
 
   object.id = id;

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -62,7 +62,7 @@ function saveEmail(id, envelope, mailObject){
   
   // remove stream object from attachments (fix the JSON.stringify)
   if (mailObject.attachments instanceof Array) {
-    mailObject.attachments.forEach((attachment) => {
+    mailObject.attachments.forEach(function(attachment) {
       delete attachment.stream;
     });
   }


### PR DESCRIPTION
Small patch to fix the error occurring when we add attachments to an email.

When maildev tries to [save the mail](https://github.com/djfarrelly/MailDev/blob/master/lib/mailserver.js#L62) by copying the mail object (returned by MailParser), we got an error `Cannot convert circular JSON`. 
It's due to the stream object left in attachments of the mail object.

I don't really know if we should blame MailParser for a breaking-change minor update, but this stream object should not be given, especially if we explicitly process the attachments with a dedicated stream (as we do with maildev).

Usage context:
- node 5.1 / es6
- [nodemailer](https://github.com/nodemailer/nodemailer)
- transporter: [amazon SES](https://github.com/andris9/nodemailer-ses-transport)
- attachments: base64 string

This patch fix the case but not sure if it can be a long-term fix, what do you think @djfarrelly ?