### PR TITLE
Reduce the size of the Docker image by switching to alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM node:5-slim
+FROM alpine:3.3
+MAINTAINER "Tony Cheneau <tony.cheneau@amnesiak.org>"
+
+ENV NODE_ENV production
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ADD package.json /usr/src/app/
-RUN npm install
+
+# do everything in one go (decrease overall image size)
+RUN apk add --no-cache nodejs &&\
+    apk add --no-cache --virtual build-dependencies python make g++ &&\
+    npm install && npm prune &&\
+    apk del build-dependencies &&\
+    rm -fr /root/.npm \
+           /root/.node-gyp \
+           /tmp/*
+
 ADD . /usr/src/app
 
 EXPOSE 80 25


### PR DESCRIPTION
Switch from node:5-slim to alpine:3.3 to reduce the image size (~270MB to ~42MB).

I also apply some cleanup commands so as to decrease the overall size of the image.

To be fair, I started this work because the standard image was segfaulting on my system (I wonder if it does that to other) and I didn't wanted to mess with the node image.