### PR TITLE
fix all inline images

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -385,7 +385,7 @@ mailServer.getEmailHTML = function(id, baseUrl, done) {
 
     if (embeddedAttachments.length) {
       embeddedAttachments.forEach(function(attachment) {
-        var regex = new RegExp('src=("|\')cid:' + attachment.contentId  + '("|\')');
+        var regex = new RegExp('src=("|\')cid:' + attachment.contentId  + '("|\')', 'g');
         var replacement = 'src="' + getFileUrl(id, baseUrl, attachment.generatedFileName) + '"';
         html = html.replace(regex, replacement);
       });


### PR DESCRIPTION
using the global flag on the search regexp applies replacement for all
matches in the document.

fixes #116