### PR TITLE
Fix relative path to relay endpoint

### DIFF
--- a/app/scripts/controllers/item.js
+++ b/app/scripts/controllers/item.js
@@ -143,7 +143,7 @@ app.controller('ItemCtrl', [
 
         $http({
           method: 'POST',
-          url: '/email/' + item.id + '/relay'
+          url: 'email/' + item.id + '/relay'
         })
           .success(function(data, status) {
             console.log('Relay result: ', data, status);


### PR DESCRIPTION
It was becoming wrong url when `basePathname` param was used.