### PR TITLE
Change source request to be lazy

### DIFF
--- a/app/scripts/controllers/item.js
+++ b/app/scripts/controllers/item.js
@@ -16,7 +16,6 @@ app.controller('ItemCtrl', [
       Email.get({ id: $routeParams.itemId }, function(email) {
 
         $scope.item = new Email(email);
-        $scope.rawEmail = 'email/' + $scope.item.id + '/source';
 
         if ($scope.item.html) {
           $scope.item.iframeUrl = 'email/' + $scope.item.id + '/html';
@@ -31,6 +30,13 @@ app.controller('ItemCtrl', [
         $location.path('/');
       });
     };
+    
+    // Get email source
+    var getSource = function() {
+      if (typeof $scope.rawEmail === 'undefined') {
+        $scope.rawEmail = 'email/' + $scope.item.id + '/source';
+      }
+    }
 
     // Prepares the iframe for interaction
     var prepIframe = function() {
@@ -109,6 +115,7 @@ app.controller('ItemCtrl', [
     // Toggle what format is viewable
     $scope.show = function(type) {
       if ((type === 'html' || type === 'attachments') && !$scope.item[type]) return;
+      if (type === 'source') getSource();
 
       $scope.panelVisibility = type;
     };


### PR DESCRIPTION
The server side uses MailParser's `streamAttachment` option to improve performance on emails with large attachments. However, the client app requests `/email/:id/html` and `/email:id/source` on item load. This moves the source call to only occur when Display --> Source is clicked.