### PR TITLE
Add --hide-extensions option that can be used to not advertise certain SMTP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,25 +26,29 @@ For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierprio
 
     maildev [options]
 
-      -h, --help                    output usage information
-      -V, --version                 output the version number
-      -s, --smtp <port>             SMTP port to catch emails [1025]
-      -w, --web <port>              Port to run the Web GUI [1080]
-      --ip <ip address>             IP Address to bind services to [0.0.0.0]
-      --outgoing-host <host>        SMTP host for outgoing emails
-      --outgoing-port <port>        SMTP port for outgoing emails
-      --outgoing-user <user>        SMTP user for outgoing emails
-      --outgoing-pass <pass>        SMTP password for outgoing emails
-      --outgoing-secure             Use SMTP SSL for outgoing emails
-      --auto-relay                  Use auto relay mode
-      --auto-relay-rules <file>     Filter rules for auto relay mode
-      --incoming-user <user>        SMTP user for incoming emails
-      --incoming-pass <pass>        SMTP password for incoming emails
-      --web-ip <ip address>         IP Address to bind HTTP service to, defaults to --ip
-      --web-user <user>             HTTP basic auth username
-      --web-pass <pass>             HTTP basic auth password
-      -o, --open                    Open the Web GUI after startup
-      -v, --verbose
+      -h, --help                      output usage information
+      -V, --version                   output the version number
+      -s, --smtp <port>               SMTP port to catch emails [1025]
+      -w, --web <port>                Port to run the Web GUI [1080]
+      --ip <ip address>               IP Address to bind SMTP service to
+      --outgoing-host <host>          SMTP host for outgoing emails
+      --outgoing-port <port>          SMTP port for outgoing emails
+      --outgoing-user <user>          SMTP user for outgoing emails
+      --outgoing-pass <password>      SMTP password for outgoing emails
+      --outgoing-secure               Use SMTP SSL for outgoing emails
+      --auto-relay                    Use auto-relay mode
+      --auto-relay-rules <file>       Filter rules for auto relay mode
+      --incoming-user <user>          SMTP user for incoming emails
+      --incoming-pass <pass>          SMTP password for incoming emails
+      --web-ip <ip address>           IP Address to bind HTTP service to, defaults to --ip
+      --web-user <user>               HTTP user for GUI
+      --web-pass <password>           HTTP password for GUI
+      --base-pathname <path>          base path for URLs
+      --hide-extensions <extensions>  Comma separated list of SMTP extensions to NOT advertise
+                                      (STARTTLS, SMTPUTF8, PIPELINING, 8BITMIME)
+      -o, --open                      Open the Web GUI after startup
+      -v, --verbose                   
+      --silent
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function(config) {
       .option('--web-user <user>', 'HTTP user for GUI')
       .option('--web-pass <password>', 'HTTP password for GUI')
       .option('--base-pathname <path>', 'base path for URLs')
+      .option('--hide-extensions <extensions>', 'Comma separated list of SMTP extensions to NOT advertise (STARTTLS, SMTPUTF8, PIPELINING, 8BITMIME)', function(val) { return val.split(','); })
       .option('-o, --open', 'Open the Web GUI after startup')
       .option('-v, --verbose')
       .option('--silent')
@@ -51,7 +52,7 @@ module.exports = function(config) {
   }
 
   // Start the Mailserver & Web GUI
-  mailserver.create(config.smtp, config.ip, config.incomingUser, config.incomingPass);
+  mailserver.create(config.smtp, config.ip, config.incomingUser, config.incomingPass, config.hideExtensions);
 
   if (config.outgoingHost ||
       config.outgoingPort ||

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -239,7 +239,8 @@ function authorizeUser(auth, session, callback) {
  * Create and configure the mailserver
  */
 
-mailServer.create = function(port, host, user, password) {
+mailServer.create = function(port, host, user, password, hideExtensions) {
+  var smtpServerConfig;
 
   // Start the server & Disable DNS checking
   if (legacy) {
@@ -258,14 +259,18 @@ mailServer.create = function(port, host, user, password) {
       smtp.on('authorizeUser', authorizeUser);
     }
   } else {
-    smtp = new SMTPServer({
+    smtpServerConfig = {
       incomingUser: user,
       incomingPassword: password,
       onAuth: authorizeUser,
       onData: handleDataStream,
       logger: false,
       disabledCommands: !!(user && password)?['STARTTLS']:['AUTH']
-    });
+    };
+
+    addHideExtensionOptions(smtpServerConfig, hideExtensions);
+
+    smtp = new SMTPServer(smtpServerConfig);
   }
 
   // Setup temp folder for attachments
@@ -274,6 +279,35 @@ mailServer.create = function(port, host, user, password) {
   mailServer.port = port || defaultPort;
   mailServer.host = host || defaultHost;
 };
+
+
+var hideableExtensions = {
+  'STARTTLS': true,
+  'PIPELINING': true,
+  '8BITMIME': true,
+  'SMTPUTF8': true
+};
+
+/**
+ * Handle settings for hiding SMTP extensions
+ */
+function addHideExtensionOptions(config, hideExtensions) {
+  if (!hideExtensions)
+    return;
+
+  for (var i in hideExtensions)
+  {
+    var extension = hideExtensions[i].toUpperCase();
+    if (extension in hideableExtensions)
+    {
+      config['hide' + extension] = true;
+    }
+    else
+    {
+      throw 'unknown SMTP extension: ' + extension;
+    }
+  }
+}
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "open": "0.0.5",
     "simplesmtp": "0.3.35",
     "smtp-connection": "2.3.1",
-    "smtp-server": "1.4.0",
+    "smtp-server": "1.16.1",
     "socket.io": "1.4.5",
     "wildstring": "1.0.8"
   },

--- a/test/api.js
+++ b/test/api.js
@@ -73,7 +73,7 @@ describe('API', function() {
         from: 'Angelo Pappas <angelo.pappas@fbi.gov>',
         to: 'Johnny Utah <johnny.utah@fbi.gov>',
         subject: 'You were right.',
-        text: 'They are surfers.'
+        text: 'They are surfers.\n'
       };
 
       maildev.listen(function(err) {
@@ -127,7 +127,7 @@ describe('API', function() {
         from: 'Angelo Pappas <angelo.pappas@fbi.gov>',
         to: 'Johnny Utah <johnny.utah@fbi.gov>',
         subject: 'You were right.',
-        text: 'They are surfers.'
+        text: 'They are surfers.\n'
       };
 
       maildev.on('new', function(email) {


### PR DESCRIPTION
I needed to test ASCII-only headers so I added this option to be able to keep the server from sending the  `SMTPUTF8` extension in the `EHLO` response.

Functionality for hiding this extension (as well as `PIPELINING` and `8BITMIME`) was added in `smtp-server` 1.10.0 so while I was at it I upgraded the `smtp-server` dependency from 1.4.0 to 1.16.1. All tests still pass after adding a newline to the end of the test mail body (see [`smtp-server` 1.11.2](https://github.com/andris9/smtp-server/blob/master/CHANGELOG.md#v1112-2016-07-15)).
