### PR TITLE
Issue 156: Shut down when receiving ctrl-c

### DIFF
--- a/bin/maildev
+++ b/bin/maildev
@@ -3,6 +3,9 @@
 var path = require('path');
 var fs = require('fs');
 
+process.on('SIGINT', process.exit); // Handle ctrl-c when running via docker run
+process.on('SIGTERM', process.exit); // Handle when we docker rm the container
+
 var root = path.join(path.dirname(fs.realpathSync(__filename)), '../');
 var MailDev = require(root + '/index.js');
 


### PR DESCRIPTION
This provides a fix for Issue 156 where you can't shut it down when running with docker.