### PR TITLE
Passing of basepath changed to a require call

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -6,7 +6,7 @@
 
 const express = require('express')
 const http = require('http')
-const io = require('socket.io')()
+let io = require('socket.io')()
 const routes = require('./routes')
 const auth = require('./auth')
 const logger = require('./logger')
@@ -80,9 +80,7 @@ web.start = function (port, host, mailserver, user, password, basePathname) {
   }
 
   if (basePathname) {
-    io.path(basePathname + '/socket.io')
-  } else {
-    basePathname = '/'
+    io = require('socket.io')({ path: basePathname + '/socket.io' })
   }
 
   app.use(basePathname, express.static(path.join(__dirname, '../app')))


### PR DESCRIPTION
Wasn't working because io.path doesn't work when attaching a server to an already defined socket.io object
closes #176