### PR TITLE
Fixes #185 on Windows

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -84,7 +84,7 @@ web.start = function (port, host, mailserver, user, password, basePathname) {
     basePathname = '/'
   }
 
-  io = socketio({ path: path.join(basePathname, '/socket.io') })
+  io = socketio({ path: path.posix.join(basePathname, '/socket.io') })
 
   app.use(basePathname, express.static(path.join(__dirname, '../app')))
 


### PR DESCRIPTION
A path gets converted to using \ instead of / on Windows. This pull fixes it.