### PR TITLE
Fix version display in GUI

### DIFF
--- a/app/views/main.html
+++ b/app/views/main.html
@@ -48,7 +48,7 @@ config.action_mailer.delivery_method = :smtp
 
     <br>
     <p>
-        <small>You are running MailDev v.{{ config.version }}</small>
+        <small>You are running MailDev v{{ config.version }}</small>
     </p>
 
 </div>


### PR DESCRIPTION
Usually, we don't display a period between the `v` and the version number.

<img width="766" alt="screen shot 2017-10-09 at 10 33 06" src="https://user-images.githubusercontent.com/5436545/31330104-472f3860-acdd-11e7-827b-6a09b811a574.png">
