### PR TITLE
Correct the configuration example for Rails (Fix #234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ const transport = nodemailer.createTransport('SMTP', {
 ```ruby
 config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-        :address => "localhost",
-        :port => 1025
+        address: "localhost",
+        port: 1025,
+        enable_starttls_auto: false
     }
 ```
 


### PR DESCRIPTION
Disable TLS in Rails' configuration example, as it's not supported.