### PR TITLE
URI encode attachment file name

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -303,7 +303,7 @@ mailServer.getEmailHTML = function (id, baseUrl, done) {
     })
 
     var getFileUrl = function (id, baseUrl, filename) {
-      return (baseUrl || '') + '/email/' + id + '/attachment/' + filename
+      return (baseUrl || '') + '/email/' + id + '/attachment/' + encodeURIComponent(filename)
     }
 
     if (embeddedAttachments.length) {


### PR DESCRIPTION
This PR adds URL encoding of attachment file names. Previously when attached image names contained characters than needed escaping, they would fail to display in HTML view. With this PR, the attachment names are correctly escaped and appear in HTML view.