### PR TITLE
Add an unread counter in the favicon

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,10 +3,11 @@
     <head>
         <meta charset="utf-8"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-        <title>{{ unreadItems > 0 ? '(' + unreadItems + ') ' : '' }}MailDev</title>
+        <title>MailDev{{ unreadItems > 0 ? ' (' + unreadItems + ')' : '' }}</title>
         <meta name="description" content="SMTP Server + Web Interface for viewing and testing emails during development.">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" href="styles/style.css">
+        <link rel="icon" id="favicon" />
     </head>
     <body>
 

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -5,8 +5,8 @@
  */
 
 app.controller('MainCtrl', [
-  '$scope', '$rootScope', '$http', 'Email', '$route', '$location',
-  function ($scope, $rootScope, $http, Email, $route, $location) {
+  '$scope', '$rootScope', '$http', 'Email', '$route', '$location', 'Favicon',
+  function ($scope, $rootScope, $http, Email, $route, $location, Favicon) {
     $scope.items = []
     $scope.configOpen = false
     $scope.currentItemId = null
@@ -17,6 +17,7 @@ app.controller('MainCtrl', [
       $scope.unreadItems = $scope.items.filter(function (email) {
         return !email.read
       }).length
+      Favicon.setUnreadCount($scope.unreadItems)
     }
 
     // Load all emails

--- a/app/scripts/services.js
+++ b/app/scripts/services.js
@@ -11,4 +11,57 @@ app.service('Email', ['$resource', function ($resource) {
       params: {}
     }
   })
+}]).service('Favicon', [function () {
+  const favicon = document.getElementById('favicon')
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+  const bufferImage = new window.Image()
+
+  var lastUnreadCount = 0
+  const faviconSize = 16
+  const pos = {
+    x: faviconSize - faviconSize / 3,
+    y: faviconSize - faviconSize / 3
+  }
+
+  bufferImage.src = './favicon.ico'
+  bufferImage.onload = function () {
+    setUnreadCount(lastUnreadCount)
+  }
+
+  canvas.width = canvas.height = faviconSize
+
+  const drawCircle = function (ctx, pos) {
+    ctx.beginPath()
+    ctx.arc(pos.x, pos.y, faviconSize / 2.4, 0, 2 * Math.PI)
+    ctx.fillStyle = '#d00'
+    ctx.fill()
+    ctx.stroke()
+  }
+
+  const drawText = function (ctx, pos, text) {
+    ctx.font = 'bold 9px "helvetica", sans-serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillStyle = '#FFFFFF'
+    ctx.fillText(text, pos.x, pos.y)
+  }
+
+  const setUnreadCount = function (unreadCount) {
+    lastUnreadCount = unreadCount
+    if (unreadCount === 0) {
+      favicon.href = bufferImage.src
+      return
+    }
+
+    context.drawImage(bufferImage, 0, 0, faviconSize, faviconSize)
+    drawCircle(context, pos)
+    drawText(context, pos, unreadCount)
+
+    favicon.href = canvas.toDataURL('image/png')
+  }
+
+  return {
+    setUnreadCount: setUnreadCount
+  }
 }])


### PR DESCRIPTION
As mentionned in https://github.com/djfarrelly/MailDev/issues/251, an unread counter placed in the favicon is more readable if the maildev tabs is pinned.
<img width="79" alt="Capture d’écran 2019-10-05 à 10 12 48" src="https://user-images.githubusercontent.com/1434700/66252196-c1702000-e758-11e9-9095-34ef0b19cf54.png">
